### PR TITLE
Fix returning GuildNotFound or PlayerNotFound Exception

### DIFF
--- a/src/main/java/io/github/neopixel/http/RequestFactory.java
+++ b/src/main/java/io/github/neopixel/http/RequestFactory.java
@@ -39,8 +39,9 @@ public class RequestFactory {
             .build();
 
         try (Response response = client.newCall(request).execute()) {
-            if (RequestValidator.isValid(response)) {
-                return new JSONObject(response.body().string());
+            JSONObject returnObject = new JSONObject(response.body().string());
+            if (RequestValidator.isValid(response, returnObject)) {
+                return returnObject;
             } else {
                 throw new NovopixelException("Fatal error, invalid response not caught.");
             }

--- a/src/main/java/io/github/neopixel/http/RequestValidator.java
+++ b/src/main/java/io/github/neopixel/http/RequestValidator.java
@@ -7,42 +7,39 @@ import io.github.neopixel.exception.InvalidDataException;
 import io.github.neopixel.exception.MissingFieldException;
 import io.github.neopixel.exception.PlayerNotFoundException;
 import io.github.neopixel.exception.UnknownAPIException;
-import java.io.IOException;
 import okhttp3.Response;
 import org.json.JSONObject;
 
 public class RequestValidator {
 
-    public static boolean isValid(Response response) {
-        try {
-            JSONObject returnObject = new JSONObject(response.body().string());
-            if (response.isSuccessful()) {
-                if (returnObject.isNull("player")) {
-                    throw new PlayerNotFoundException("Player not found.");
-                } else if (returnObject.isNull("guild")) {
-                    throw new GuildNotFoundException("Guild not found.");
-                } else {
-                    return true;
-                }
-            } else {
-                String failString = returnObject.getString("cause");
-
-                switch (response.code()) {
-                    case 400:
-                        throw new MissingFieldException(failString);
-                    case 403:
-                        throw new ForbiddenAccessException(failString);
-                    case 422:
-                        throw new InvalidDataException(failString);
-                    case 429:
-                        throw new KeyThrottleException(failString);
-                    default:
-                        throw new UnknownAPIException(failString);
-                }
+    public static boolean isValid(Response response, JSONObject returnObject) {
+        if (response.isSuccessful()) {
+            if (!returnObject.isNull("player") || !returnObject.isNull("guild")) {
+                return true;
+            } else if (returnObject.isNull("player")) {
+                throw new PlayerNotFoundException("Player not found.");
+            } else if (returnObject.isNull("guild")) {
+                throw new GuildNotFoundException("Guild not found.");
             }
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+        } else {
+
+            String failString = returnObject.getString("cause");
+
+            switch (response.code()) {
+                case 400:
+                    throw new MissingFieldException(failString);
+                case 403:
+                    throw new ForbiddenAccessException(failString);
+                case 422:
+                    throw new InvalidDataException(failString);
+                case 429:
+                    throw new KeyThrottleException(failString);
+                default:
+                    throw new UnknownAPIException(failString);
+            }
         }
+        return false;
     }
+
 }
 


### PR DESCRIPTION
An exception would be thrown if either the Guild object or Player object returned null. Obviously, this would not work because the user will only make one API call at a time. This commit fixes that by asserting neither object returns true before throwing the error.