### PR TITLE
Fix legacy exception (fixed typo)

### DIFF
--- a/src/main/java/io/github/neopixel/exception/NeopixelException.java
+++ b/src/main/java/io/github/neopixel/exception/NeopixelException.java
@@ -15,7 +15,7 @@ public class NeopixelException extends RuntimeException {
 
     @Override
     public String toString() {
-        return "NeoException: " +
+        return "NeopixelException: " +
             "API response = '" + message + '\'';
     }
 }


### PR DESCRIPTION
I accidentally made a typo saying "NeoException" instead of "NeopixelException" in my previous PR. Please actually review it next time before merging.